### PR TITLE
Add GetProfile endpoint and user profile retrieval

### DIFF
--- a/Lumix.API/Controllers/UserController.cs
+++ b/Lumix.API/Controllers/UserController.cs
@@ -50,4 +50,15 @@ public class UserController : ControllerBase
             return NotFound(ex.Message);
         }
     }
+    [Authorize]
+    [HttpGet("profile")]
+    public async Task<ActionResult<UserProfileDto>> GetProfile()
+    {
+        var userId = HttpContext.GetUserId();
+        if (!userId.HasValue)
+            return Unauthorized();
+        var profile = await _userService.GetProfileAsync(userId.Value);
+        
+        return Ok(profile);
+    }
 }

--- a/Lumix.Application/Services/UserService.cs
+++ b/Lumix.Application/Services/UserService.cs
@@ -26,4 +26,28 @@ public class UserService : IUserService
 
         return await _usersRepository.UpdateUsernameAsync(userId, username);
     }
+
+    public async Task<UserProfileDto> GetProfileAsync(Guid userId)
+    {
+        var user = await _usersRepository.GetByIdAsync(userId);
+
+        return new UserProfileDto
+        {
+            Id = user.Id,
+            Username = user.Username,
+            ProfilePictureUrl = user.ProfilePictureUrl,
+            Bio = user.Bio,
+            FollowersCount = user.Followers.Count(),
+            FollowingCount = user.Following.Count(),
+            PhotosCount = user.Photos.Count(),
+            Photos = user.Photos
+                .OrderByDescending(p => p.CreatedAt)
+                .Select(p => new PhotoPrewiewDto
+                {
+                    Id = p.Id,
+                    Url = p.Url
+                })
+                .ToList()
+        };
+    }
 }

--- a/Lumix.Core/DTOs/PhotoPrewiewDto.cs
+++ b/Lumix.Core/DTOs/PhotoPrewiewDto.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lumix.Core.DTOs
+{
+    public class PhotoPrewiewDto
+    {
+        public Guid Id { get; set; }
+        public string Url { get; set; } = string.Empty;
+    }
+}

--- a/Lumix.Core/DTOs/UserProfileDto.cs
+++ b/Lumix.Core/DTOs/UserProfileDto.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lumix.Core.DTOs
+{
+    public class UserProfileDto
+    {
+        public Guid Id { get; set; }
+        public string Username { get; set; } = string.Empty;
+        public string ProfilePictureUrl { get; set; } = string.Empty;
+        public string Bio { get; set; } = string.Empty;
+
+        public int FollowersCount { get; set; }
+        public int FollowingCount { get; set; }
+        public int PhotosCount { get; set; }
+
+        public List<PhotoPrewiewDto> Photos { get; set; } = new();
+    }
+}

--- a/Lumix.Core/Interfaces/Repositories/IUsersRepository.cs
+++ b/Lumix.Core/Interfaces/Repositories/IUsersRepository.cs
@@ -1,9 +1,9 @@
 using Lumix.Core.DTOs;
-
 namespace Lumix.Core.Interfaces.Repositories;
 
 public interface IUsersRepository
 {
     Task<UserDto> GetByEmail(string email);
     Task<UserDto> UpdateUsernameAsync(Guid userId, string username);
+    Task<UserDto> GetByIdAsync(Guid userId);
 }

--- a/Lumix.Core/Interfaces/Services/IUserService.cs
+++ b/Lumix.Core/Interfaces/Services/IUserService.cs
@@ -5,4 +5,5 @@ namespace Lumix.Core.Interfaces.Services;
 public interface IUserService
 {
     Task<UserDto> UpdateUsernameAsync(Guid userId, string username);
+    Task<UserProfileDto> GetProfileAsync(Guid userId);
 }

--- a/Lumix.Persistence/Repositories/UsersRepository.cs
+++ b/Lumix.Persistence/Repositories/UsersRepository.cs
@@ -44,4 +44,11 @@ public class UsersRepository : IUsersRepository
 
         return _mapper.Map<UserDto>(user);
     }
+
+    public async Task<UserDto> GetByIdAsync(Guid userId)
+    {
+        var user = await _context.Users.FindAsync(userId)
+            ?? throw new InvalidOperationException("User not found");
+        return _mapper.Map<UserDto>(user);
+    }
 }


### PR DESCRIPTION
Add GetProfile endpoint and user profile retrieval

Introduced a new `GetProfile` endpoint in `UserController` to allow authenticated users to retrieve their profile information. Added `GetProfileAsync` in `UserService` to handle profile retrieval logic, including followers, following, and photos.

Updated `IUserService` and `IUsersRepository` interfaces to include `GetProfileAsync` and `GetByIdAsync` methods, respectively. Implemented `GetByIdAsync` in `UsersRepository` to fetch user data by ID.

Added `UserProfileDto` and `PhotoPrewiewDto` to structure profile and photo data. Updated necessary namespaces and `using` directives for the new DTOs.