### PR TITLE
Add support for nested comments

### DIFF
--- a/Lumix.API/Contracts/Requests/CommentRequest.cs
+++ b/Lumix.API/Contracts/Requests/CommentRequest.cs
@@ -1,0 +1,8 @@
+﻿namespace Lumix.API.Contracts.Requests
+{
+    public class CommentRequest
+    {
+        public string Text { get; set; } = string.Empty;
+        public Guid? ParentId { get; set; }
+    }
+}

--- a/Lumix.API/Controllers/CommentController.cs
+++ b/Lumix.API/Controllers/CommentController.cs
@@ -17,7 +17,7 @@ namespace Lumix.API.Controllers
 		}
 
 		[HttpPost("{id:guid}")]
-		public async Task<IActionResult> PostComment(Guid id, [FromForm] CommentRequest request)
+		public async Task<IActionResult> PostComment(Guid id, [FromBody] CommentRequest request)
 		{
 			try
 			{
@@ -27,8 +27,8 @@ namespace Lumix.API.Controllers
 					return Unauthorized();
 				}
 
-				await _commentService.AddComment(userId, id, request.Text, request.ParentId);
-				return Ok();
+				var created = await _commentService.AddComment(userId, id, request.Text, request.ParentId);
+				return Ok(created);
 			}
 			catch (Exception ex)
 			{

--- a/Lumix.API/Controllers/CommentController.cs
+++ b/Lumix.API/Controllers/CommentController.cs
@@ -1,4 +1,5 @@
-﻿using Lumix.API.Extensions;
+﻿using Lumix.API.Contracts.Requests;
+using Lumix.API.Extensions;
 using Lumix.Core.Interfaces.Services;
 using Microsoft.AspNetCore.Mvc;
 
@@ -16,7 +17,7 @@ namespace Lumix.API.Controllers
 		}
 
 		[HttpPost("{id:guid}")]
-		public async Task<IActionResult> PostComment(Guid id, [FromForm] string commentText)
+		public async Task<IActionResult> PostComment(Guid id, [FromForm] CommentRequest request)
 		{
 			try
 			{
@@ -26,7 +27,7 @@ namespace Lumix.API.Controllers
 					return Unauthorized();
 				}
 
-				await _commentService.AddComment(userId, id, commentText);
+				await _commentService.AddComment(userId, id, request.Text, request.ParentId);
 				return Ok();
 			}
 			catch (Exception ex)

--- a/Lumix.Application/Services/CommentService.cs
+++ b/Lumix.Application/Services/CommentService.cs
@@ -32,10 +32,10 @@ namespace Lumix.Application.Services
 
 		public async Task<IEnumerable<CommentDto>> GetByPhotoId(Guid photoId)
 		{
-			var flatDtos = await _commentsRepository.GetByPhotoId(photoId)
+			var allComments = await _commentsRepository.GetByPhotoId(photoId)
 				?? Enumerable.Empty<CommentDto>();
 
-            var tree = BuildTree(flatDtos.ToList());
+            var tree = BuildTree(allComments.ToList());
 			return tree;
 		}
 

--- a/Lumix.Application/Services/CommentService.cs
+++ b/Lumix.Application/Services/CommentService.cs
@@ -13,7 +13,7 @@ namespace Lumix.Application.Services
 			_commentsRepository = commentsRepository;
 		}
 
-		public async Task AddComment(Guid userId, Guid photoId, string commentText)
+		public async Task AddComment(Guid userId, Guid photoId, string commentText, Guid? parentId)
 		{
 			var comment = new CommentDto
 			{
@@ -21,16 +21,41 @@ namespace Lumix.Application.Services
 				UserId = userId,
 				PhotoId = photoId,
 				Text = commentText,
-				CreatedAt = DateTime.UtcNow
-			};
+				CreatedAt = DateTime.UtcNow,
+				ParentId = parentId
+            };
 
 
             await _commentsRepository.Add(comment);
 		}
 
-		public async Task<IEnumerable<CommentDto>?> GetByPhotoId(Guid photoId)
+		public async Task<IEnumerable<CommentDto>> GetByPhotoId(Guid photoId)
 		{
-			return await _commentsRepository.GetByPhotoId(photoId);
+			var flatDtos = await _commentsRepository.GetByPhotoId(photoId)
+				?? Enumerable.Empty<CommentDto>();
+
+            var tree = BuildTree(flatDtos.ToList());
+			return tree;
 		}
-	}
+
+        private static List<CommentDto> BuildTree(List<CommentDto> flat)
+        {
+            var lookup = flat.ToDictionary(c => c.Id);
+            var roots = new List<CommentDto>();
+
+            foreach (var comment in flat)
+            {
+                if (comment.ParentId == null)
+                {
+                    roots.Add(comment);
+                }
+                else if (lookup.TryGetValue(comment.ParentId.Value, out var parent))
+                {
+                    parent.Children.Add(comment);
+                }
+            }
+
+            return roots;
+        }
+    }
 }

--- a/Lumix.Application/Services/CommentService.cs
+++ b/Lumix.Application/Services/CommentService.cs
@@ -13,7 +13,7 @@ namespace Lumix.Application.Services
 			_commentsRepository = commentsRepository;
 		}
 
-		public async Task AddComment(Guid userId, Guid photoId, string commentText, Guid? parentId)
+		public async Task<CommentDto> AddComment(Guid userId, Guid photoId, string commentText, Guid? parentId)
 		{
 			var comment = new CommentDto
 			{
@@ -26,7 +26,8 @@ namespace Lumix.Application.Services
             };
 
 
-            await _commentsRepository.Add(comment);
+            var created = await _commentsRepository.AddAsync(comment);
+			return created;
 		}
 
 		public async Task<IEnumerable<CommentDto>> GetByPhotoId(Guid photoId)

--- a/Lumix.Core/DTOs/CommentDto.cs
+++ b/Lumix.Core/DTOs/CommentDto.cs
@@ -7,7 +7,10 @@
 		public Guid PhotoId { get; set; }
 		public string Text { get; set; } = string.Empty;
 		public DateTime CreatedAt { get; set; }
+		public Guid? ParentId { get; set; }
+		public List<CommentDto> Children { get; set; } = new();
+		public UserPreviewDto Author { get; set; } = new();
 
-		
-	}
+
+    }
 }

--- a/Lumix.Core/Interfaces/Repositories/ICommentsRepository.cs
+++ b/Lumix.Core/Interfaces/Repositories/ICommentsRepository.cs
@@ -4,7 +4,7 @@ namespace Lumix.Core.Interfaces.Repositories
 {
 	public interface ICommentsRepository
 	{
-		Task Add(CommentDto comment);
+		Task<CommentDto> AddAsync(CommentDto comment);
 		Task<IEnumerable<CommentDto>?> GetByPhotoId(Guid photoId);
 	}
 }

--- a/Lumix.Core/Interfaces/Services/ICommentService.cs
+++ b/Lumix.Core/Interfaces/Services/ICommentService.cs
@@ -4,7 +4,7 @@ namespace Lumix.Core.Interfaces.Services
 {
 	public interface ICommentService
 	{
-		Task AddComment(Guid userId, Guid photoId, string commentText, Guid? parentId);
+		Task<CommentDto> AddComment(Guid userId, Guid photoId, string commentText, Guid? parentId);
 		Task<IEnumerable<CommentDto>> GetByPhotoId(Guid photoId);
 	}
 }

--- a/Lumix.Core/Interfaces/Services/ICommentService.cs
+++ b/Lumix.Core/Interfaces/Services/ICommentService.cs
@@ -4,7 +4,7 @@ namespace Lumix.Core.Interfaces.Services
 {
 	public interface ICommentService
 	{
-		Task AddComment(Guid userId, Guid photoId, string commentText);
-		Task<IEnumerable<CommentDto>?> GetByPhotoId(Guid photoId);
+		Task AddComment(Guid userId, Guid photoId, string commentText, Guid? parentId);
+		Task<IEnumerable<CommentDto>> GetByPhotoId(Guid photoId);
 	}
 }

--- a/Lumix.Persistence/Configurations/CommentConfiguration.cs
+++ b/Lumix.Persistence/Configurations/CommentConfiguration.cs
@@ -23,6 +23,11 @@ namespace Lumix.Persistence.Configurations
 				.WithMany(p => p.Comments)
 				.HasForeignKey(c => c.PhotoId)
 				.OnDelete(DeleteBehavior.Cascade);
+
+			builder.HasOne(c => c.Parent)
+				.WithMany(c => c.Children)
+				.HasForeignKey(c => c.ParentId)
+				.OnDelete(DeleteBehavior.NoAction);
 		}
 	}
 }

--- a/Lumix.Persistence/DataBaseMappings.cs
+++ b/Lumix.Persistence/DataBaseMappings.cs
@@ -17,7 +17,8 @@ public class DataBaseMappings : Profile
         CreateMap<Photo, PhotoDto>()
             .ForMember(d => d.Author, o => o.MapFrom(s => s.User));
         CreateMap<Like, LikeDto>();
-        CreateMap<Comment, CommentDto>();
+        CreateMap<Comment, CommentDto>()
+            .ForMember(d => d.Author, o => o.MapFrom(s => s.User));
         CreateMap<Follow, FollowDto>();
         CreateMap<Tag, TagDto>()
             .ForMember(d => d.PhotoTags, o => o.Ignore());

--- a/Lumix.Persistence/Entities/Comment.cs
+++ b/Lumix.Persistence/Entities/Comment.cs
@@ -8,6 +8,10 @@ public class Comment
     public string Text { get; set; } = string.Empty;
     public DateTime CreatedAt { get; set; }
 
+    public Guid? ParentId { get; set; }
+    public Comment? Parent { get; set; }
+    public List<Comment> Children { get; set; } = new List<Comment>();
+
     public User? User { get; set; }
     public Photo? Photo { get; set; }
 }

--- a/Lumix.Persistence/Migrations/20251205201924_AddParentComment.Designer.cs
+++ b/Lumix.Persistence/Migrations/20251205201924_AddParentComment.Designer.cs
@@ -4,6 +4,7 @@ using Lumix.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Lumix.Persistence.Migrations
 {
     [DbContext(typeof(LumixDbContext))]
-    partial class LumixDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251205201924_AddParentComment")]
+    partial class AddParentComment
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Lumix.Persistence/Migrations/20251205201924_AddParentComment.cs
+++ b/Lumix.Persistence/Migrations/20251205201924_AddParentComment.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Lumix.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddParentComment : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ParentId",
+                table: "Comments",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Comments_ParentId",
+                table: "Comments",
+                column: "ParentId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Comments_Comments_ParentId",
+                table: "Comments",
+                column: "ParentId",
+                principalTable: "Comments",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Comments_Comments_ParentId",
+                table: "Comments");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Comments_ParentId",
+                table: "Comments");
+
+            migrationBuilder.DropColumn(
+                name: "ParentId",
+                table: "Comments");
+        }
+    }
+}

--- a/Lumix.Persistence/Repositories/CommentsRepository.cs
+++ b/Lumix.Persistence/Repositories/CommentsRepository.cs
@@ -25,7 +25,8 @@ namespace Lumix.Persistence.Repositories
 				UserId = comment.UserId,
 				PhotoId = comment.PhotoId,
 				Text = comment.Text,
-				CreatedAt = comment.CreatedAt
+				CreatedAt = comment.CreatedAt,
+				ParentId = comment.ParentId
 			};
 
 			await _context.Comments.AddAsync(commentEntity);
@@ -37,7 +38,9 @@ namespace Lumix.Persistence.Repositories
 			var comments = await _context.Comments
 				.AsNoTracking()
 				.Where(p => p.PhotoId == photoId)
-				.ToListAsync();
+				.Include(c => c.User)
+				.OrderBy(c => c.CreatedAt)
+                .ToListAsync();
 
 			return _mapper.Map<IEnumerable<CommentDto>?>(comments);
 		}

--- a/Lumix.Persistence/Repositories/CommentsRepository.cs
+++ b/Lumix.Persistence/Repositories/CommentsRepository.cs
@@ -17,7 +17,7 @@ namespace Lumix.Persistence.Repositories
 			_mapper = mapper;
 		}
 
-		public async Task Add(CommentDto comment)
+		public async Task<CommentDto> AddAsync(CommentDto comment)
 		{
 			var commentEntity = new Comment()
 			{
@@ -31,7 +31,13 @@ namespace Lumix.Persistence.Repositories
 
 			await _context.Comments.AddAsync(commentEntity);
 			await _context.SaveChangesAsync();
-		}
+
+			await _context.Entry(commentEntity)
+				.Reference(c => c.User)
+				.LoadAsync();
+
+			return _mapper.Map<CommentDto>(commentEntity);
+        }
 
 		public async Task<IEnumerable<CommentDto>?> GetByPhotoId(Guid photoId)
 		{


### PR DESCRIPTION
Add support for nested comments

Introduced hierarchical comment support by adding a `ParentId` property to enable parent-child relationships. Updated the `Comment` entity, `CommentDto`, and `CommentRequest` to include `ParentId` and `Children` properties. Enhanced `CommentService` with a `BuildTree` method to return comments as a tree structure.

Modified `CommentController` to accept `CommentRequest` for creating nested comments. Updated `ICommentService` and `CommentsRepository` to handle parent-child relationships and include user details in comments.

Added a migration to update the `Comments` table with a `ParentId` column and foreign key constraints. Updated `CommentConfiguration` and `DataBaseMappings` to reflect these changes. Improved the data model and API to support nested comment creation and retrieval.
