### PR TITLE
Set thumbnail url in PhotoPreviewDto

### DIFF
--- a/Lumix.Application/Extensions/PhotoExtensions.cs
+++ b/Lumix.Application/Extensions/PhotoExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lumix.Application.Extensions
+{
+    public static class PhotoExtensions
+    {
+        public static string BuildThumbnailUrl(this string photoUrl, Guid photoId)
+        {
+            var lastSlashIndex = photoUrl.LastIndexOf('/');
+            if (lastSlashIndex == -1)
+                return photoUrl;
+            var baseUrl = photoUrl.Substring(0, lastSlashIndex);
+            return $"{baseUrl}/thumbnail_{photoId}";
+        }
+    }
+}

--- a/Lumix.Infrastructure/PhotoUpload/S3BucketService.cs
+++ b/Lumix.Infrastructure/PhotoUpload/S3BucketService.cs
@@ -63,8 +63,9 @@ namespace Lumix.Infrastructure.PhotoUpload
 			{
 				BucketName = BUCKET_NAME,
 				Key = $"{userId}/thumbnail_{photoId}",
-				InputStream = modifiedPhoto.OpenReadStream()
-			};
+				InputStream = modifiedPhoto.OpenReadStream(),
+				CannedACL = S3CannedACL.PublicRead
+            };
 
 			var response = await _client.PutObjectAsync(request);
 			if (response.HttpStatusCode != HttpStatusCode.OK)

--- a/Lumix.Persistence/Repositories/UsersRepository.cs
+++ b/Lumix.Persistence/Repositories/UsersRepository.cs
@@ -1,8 +1,8 @@
 using AutoMapper;
 using Lumix.Core.DTOs;
 using Lumix.Core.Interfaces.Repositories;
-using Lumix.Persistence.Entities;
 using Microsoft.EntityFrameworkCore;
+using Lumix.Application.Extensions;
 
 namespace Lumix.Persistence.Repositories;
 
@@ -85,18 +85,11 @@ public class UsersRepository : IUsersRepository
             .Select(p => new PhotoPrewiewDto
             {
                 Id = p.Id,
-                Url = BuildThumbnailUrl(p.Url, p.Id)
+                Url = p.Url.BuildThumbnailUrl(p.Id)
             })
             .ToList()
         };
     }
 
-    private string BuildThumbnailUrl(string photoUrl, Guid photoId)
-    {
-        var lastSlashIndex = photoUrl.LastIndexOf('/');
-        if(lastSlashIndex == -1)
-            return photoUrl;
-        var baseUrl = photoUrl.Substring(0, lastSlashIndex);
-        return $"{baseUrl}/thumbnail_{photoId}";
-    }
+    
 }

--- a/Lumix.Persistence/Repositories/UsersRepository.cs
+++ b/Lumix.Persistence/Repositories/UsersRepository.cs
@@ -85,9 +85,18 @@ public class UsersRepository : IUsersRepository
             .Select(p => new PhotoPrewiewDto
             {
                 Id = p.Id,
-                Url = p.Url
+                Url = BuildThumbnailUrl(p.Url, p.Id)
             })
             .ToList()
         };
+    }
+
+    private string BuildThumbnailUrl(string photoUrl, Guid photoId)
+    {
+        var lastSlashIndex = photoUrl.LastIndexOf('/');
+        if(lastSlashIndex == -1)
+            return photoUrl;
+        var baseUrl = photoUrl.Substring(0, lastSlashIndex);
+        return $"{baseUrl}/thumbnail_{photoId}";
     }
 }


### PR DESCRIPTION
# PR Summary
### Set thumbnail url in `PhotoPreviewDto`
Changes included:
- Updated `S3BucketService.UploadThumbnailToStorage()` to upload thumbnails with `PublicRead` ACL, ensuring public availability of preview images.
- Added `BuildThumbnailUrl()` helper to `UsersRepository` to generate thumbnail URLs based on the original photo path.