### PR TITLE
Refactor photo deletion for ownership and error handling

### DIFF
--- a/Lumix.API/Controllers/UserController.cs
+++ b/Lumix.API/Controllers/UserController.cs
@@ -61,4 +61,15 @@ public class UserController : ControllerBase
         
         return Ok(profile);
     }
+
+    [Authorize]
+    [HttpGet("me")]
+    public ActionResult<Guid> GetCurrentUserId()
+    {
+        var userId = HttpContext.GetUserId();
+        if (!userId.HasValue)
+            return Unauthorized();
+        
+        return Ok(userId.Value);
+    }
 }

--- a/Lumix.Application/Services/PhotoService.cs
+++ b/Lumix.Application/Services/PhotoService.cs
@@ -83,9 +83,22 @@ namespace Lumix.Application.Services
 			await _photosRepository.Update(photoToUpdate);
 		}
 
-		public async Task Delete(Guid id)
-		{
-			await _photosRepository.DeleteById(id);
-		}
+		public async Task Delete(Guid photoId, Guid currentUserId)
+        {
+			PhotoDto photo;
+            try
+            {
+                photo = await _photosRepository.GetById(photoId);
+            }
+            catch (InvalidOperationException)
+            {
+                throw new KeyNotFoundException("Фото не знайдено.");
+            }
+
+            if (photo.UserId != currentUserId)
+                throw new UnauthorizedAccessException("Ви не є власником фото.");
+
+			await _photosRepository.DeleteById(photoId);
+        }
 	}
 }

--- a/Lumix.Core/Interfaces/Services/IPhotoService.cs
+++ b/Lumix.Core/Interfaces/Services/IPhotoService.cs
@@ -12,6 +12,6 @@ namespace Lumix.Core.Interfaces.Services
 		Task<bool> IsPhotoBelongToUser(Guid userId, Guid photoId);
 		Task<IEnumerable<PhotoDto>> GetAllUserPhotos(Guid userId);
 		Task UpdateInfo(PhotoDto photoToUpdate, string newTitle);
-		Task Delete(Guid id);
+		Task Delete(Guid photoId, Guid currentUserId);
 	}
 }


### PR DESCRIPTION
Refactor photo deletion for ownership and error handling

- Update PhotoController.DeleteById to check ownership, improve error handling, and add logging for storage failures.
- Change IPhotoService.Delete to require current user ID and enforce ownership.
- Remove old deletion logic from controller and service.
- Inject ILogger into PhotoController.
- Add GET /me endpoint in UserController to return current user ID.