### PR TITLE
Add robust comment and photo deletion

### DIFF
--- a/Lumix.API/Controllers/CommentController.cs
+++ b/Lumix.API/Controllers/CommentController.cs
@@ -55,5 +55,29 @@ namespace Lumix.API.Controllers
 				return BadRequest(ex.Message);
 			}
 		}
+
+        [HttpDelete("{id:guid}/{photoId:guid}")]
+        public async Task<IActionResult> DeleteComment(Guid id, Guid photoId)
+        {
+            try
+            {
+                var userId = HttpContext.GetUserId() ?? Guid.Empty;
+                if (userId == Guid.Empty)
+                {
+                    return Unauthorized();
+                }
+
+                await _commentService.DeleteById(id, photoId, userId);
+                return NoContent();
+            }
+            catch (InvalidOperationException)
+            {
+                return NotFound();
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return Forbid();
+            }
+        }
 	}
 }

--- a/Lumix.API/Controllers/PhotoController.cs
+++ b/Lumix.API/Controllers/PhotoController.cs
@@ -16,18 +16,16 @@ namespace Lumix.API.Controllers
 		private readonly IPhotoTagService _photoTagService;
 		private readonly IUserService _userService;
         private readonly IFileStorageService _storageService;
-		private readonly ILogger<PhotoController> _logger;
 
 		public PhotoController(IPhotoService photoService, ITagService service, 
             IPhotoTagService photoTagService, IFileStorageService storageService, 
-            IUserService userService, ILogger<PhotoController> logger)
+            IUserService userService)
 		{
 			_photoService = photoService;
 			_tagService = service;
 			_photoTagService = photoTagService;
 			_storageService = storageService;
 			_userService = userService;
-			_logger = logger;
         }
 
 		[HttpPost("upload")]
@@ -162,25 +160,8 @@ namespace Lumix.API.Controllers
 
             try
             {
-                var photo = await _photoService.GetById(photoId);
-
-                await _photoService.Delete(photoId, userId.Value);
-
-                try
-                {
-                    await _storageService.DeleteFileFromStorage(photo.Url, userId.Value);
-                    await _storageService.DeleteThumbnailFromStorage(photo.Url, userId.Value);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Failed to delete from S3: {Url}", photo.Url);
-                }
-
+                await _photoService.FullDelete(photoId, userId.Value);
                 return NoContent();
-            }
-            catch (InvalidOperationException)
-            {
-                return NotFound();
             }
             catch (KeyNotFoundException)
             {

--- a/Lumix.Application/Lumix.Application.csproj
+++ b/Lumix.Application/Lumix.Application.csproj
@@ -17,6 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Lumix.Application/Services/CommentService.cs
+++ b/Lumix.Application/Services/CommentService.cs
@@ -7,11 +7,13 @@ namespace Lumix.Application.Services
 	public class CommentService : ICommentService
 	{
 		private readonly ICommentsRepository _commentsRepository;
+		private readonly IPhotosRepository _photosRepository;
 
-		public CommentService(ICommentsRepository commentsRepository)
+        public CommentService(ICommentsRepository commentsRepository, IPhotosRepository photosRepository)
 		{
 			_commentsRepository = commentsRepository;
-		}
+			_photosRepository = photosRepository;
+        }
 
 		public async Task<CommentDto> AddComment(Guid userId, Guid photoId, string commentText, Guid? parentId)
 		{
@@ -57,6 +59,17 @@ namespace Lumix.Application.Services
             }
 
             return roots;
+        }
+
+        public async Task DeleteById(Guid commentId, Guid photoId, Guid currentUserId)
+        {
+            var photo = await _photosRepository.GetById(photoId);
+            var comment = await _commentsRepository.GetById(commentId);
+
+            if (comment.Author.Id != currentUserId && photo.UserId != currentUserId)
+                throw new UnauthorizedAccessException();
+
+            await _commentsRepository.DeleteById(commentId);
         }
     }
 }

--- a/Lumix.Application/Services/PhotoService.cs
+++ b/Lumix.Application/Services/PhotoService.cs
@@ -1,20 +1,25 @@
-﻿using Lumix.Core.DTOs;
+﻿using Lumix.Application.PhotoUpload;
+using Lumix.Core.DTOs;
 using Lumix.Core.Interfaces.Repositories;
 using Lumix.Core.Interfaces.Services;
-using static System.Runtime.InteropServices.JavaScript.JSType;
+using Microsoft.Extensions.Logging;
 
 namespace Lumix.Application.Services
 {
 	public class PhotoService : IPhotoService
 	{
 		private readonly IPhotosRepository _photosRepository;
+		private readonly IFileStorageService _storageService;
+		private readonly ILogger<PhotoService> _logger;
 
-		private const int PHOTOS_COUNT_ON_PAGE = 10;
+        private const int PHOTOS_COUNT_ON_PAGE = 10;
 
-		public PhotoService(IPhotosRepository photosRepository)
+		public PhotoService(IPhotosRepository photosRepository, IFileStorageService storageService, ILogger<PhotoService> logger)
 		{
 			_photosRepository = photosRepository;
-		}
+			_storageService = storageService;
+			_logger = logger;
+        }
 
 		public async Task<Guid> Upload(string title, string url, Guid photoId, Guid userId, bool isAvatar)
 		{
@@ -85,7 +90,32 @@ namespace Lumix.Application.Services
 
 		public async Task Delete(Guid photoId, Guid currentUserId)
         {
-			PhotoDto photo;
+            var photo = await GetPhotoIfBelongsToUser(photoId, currentUserId);
+
+			await _photosRepository.DeleteById(photo.Id);
+        }
+
+        public async Task FullDelete(Guid photoId, Guid currentUserId)
+        {
+            var photo = await GetPhotoIfBelongsToUser(photoId, currentUserId);
+
+            await _photosRepository.DeleteById(photo.Id);
+
+            try
+            {
+                await _storageService.DeleteFileFromStorage(photo.Url, currentUserId);
+                await _storageService.DeleteThumbnailFromStorage(photo.Url, currentUserId);
+            }catch(InvalidOperationException ex)
+			{
+                _logger.LogError(ex,
+                    "Failed to delete photo from S3. PhotoId={PhotoId}, Url={Url}, UserId={UserId}",
+                    photo.Id, photo.Url, currentUserId);
+            }
+        }
+
+        private async Task<PhotoDto> GetPhotoIfBelongsToUser(Guid photoId, Guid userId)
+        {
+            PhotoDto photo;
             try
             {
                 photo = await _photosRepository.GetById(photoId);
@@ -95,10 +125,10 @@ namespace Lumix.Application.Services
                 throw new KeyNotFoundException("Фото не знайдено.");
             }
 
-            if (photo.UserId != currentUserId)
+            if (photo.UserId != userId)
                 throw new UnauthorizedAccessException("Ви не є власником фото.");
 
-			await _photosRepository.DeleteById(photoId);
+			return photo;
         }
 	}
 }

--- a/Lumix.Core/Interfaces/Repositories/ICommentsRepository.cs
+++ b/Lumix.Core/Interfaces/Repositories/ICommentsRepository.cs
@@ -5,6 +5,8 @@ namespace Lumix.Core.Interfaces.Repositories
 	public interface ICommentsRepository
 	{
 		Task<CommentDto> AddAsync(CommentDto comment);
+        Task<CommentDto> GetById(Guid commentId);
 		Task<IEnumerable<CommentDto>?> GetByPhotoId(Guid photoId);
-	}
+        Task DeleteById(Guid id);
+    }
 }

--- a/Lumix.Core/Interfaces/Services/ICommentService.cs
+++ b/Lumix.Core/Interfaces/Services/ICommentService.cs
@@ -6,5 +6,6 @@ namespace Lumix.Core.Interfaces.Services
 	{
 		Task<CommentDto> AddComment(Guid userId, Guid photoId, string commentText, Guid? parentId);
 		Task<IEnumerable<CommentDto>> GetByPhotoId(Guid photoId);
-	}
+        Task DeleteById(Guid commentId, Guid photoId, Guid currentUserId);
+    }
 }

--- a/Lumix.Core/Interfaces/Services/IPhotoService.cs
+++ b/Lumix.Core/Interfaces/Services/IPhotoService.cs
@@ -13,5 +13,7 @@ namespace Lumix.Core.Interfaces.Services
 		Task<IEnumerable<PhotoDto>> GetAllUserPhotos(Guid userId);
 		Task UpdateInfo(PhotoDto photoToUpdate, string newTitle);
 		Task Delete(Guid photoId, Guid currentUserId);
-	}
+        Task FullDelete(Guid photoId, Guid currentUserId);
+
+    }
 }


### PR DESCRIPTION
Add robust comment and photo deletion

- Added DELETE endpoint for comments; only authors or photo owners can delete
- Refactored photo deletion to service layer with storage cleanup and error logging
- Updated services and repositories for authorization and error handling
- Introduced logging and improved dependency injection
- Added `Microsoft.Extensions.Logging.Abstractions` package